### PR TITLE
PhantomJS Executable Download only for Testing

### DIFF
--- a/.github/workflows/phantomjs-test.yml
+++ b/.github/workflows/phantomjs-test.yml
@@ -22,15 +22,6 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-       # Install available Docker Libraries
-#      - name: Install available Docker Libraries
-#        run: |
-#          sudo apt-get update 
-#          sudo apt-cache search containerd | sort
-#          sudo apt-cache show containerd
-#          sudo apt-get install containerd docker.io docker-compose
-#          sudo usermod -aG docker runner
-
        # List all installed Docker Libraries
       - name: List all installed Docker Libraries
         run: |
@@ -41,11 +32,20 @@ jobs:
 #          sudo systemctl start docker
       - name: Start Docker Engine
         run: |
-          sudo systemctl status docker -l
-          
+          sudo systemctl status docker -l          
+        
         
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+
+
+       # Download PhantomJS Executable
+      - name: Download and Install PhantomJS Executable
+        run: |
+          cd ../  
+          wget -S https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
+          tar -xjf phantomjs-2.1.1-linux-x86_64.tar.bz2
+          cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs plack-pwa-web/bin/
 
       - name: Listing Directory Contents
         run: |

--- a/.github/workflows/phantomjs-test.yml
+++ b/.github/workflows/phantomjs-test.yml
@@ -46,6 +46,8 @@ jobs:
           wget -S https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
           tar -xjf phantomjs-2.1.1-linux-x86_64.tar.bz2
           cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs plack-pwa-web/bin/
+          echo "Testing and Installing Tools:"
+          ls -lah plack-pwa-web/bin/
 
       - name: Listing Directory Contents
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .node-gyp
 node_modules
 
+#Project Files
+.project
+
 #Installation Logs
 .cpanm
 blib
@@ -10,11 +13,9 @@ perl5
 log
 log/*
 
-#Project Files
-.project
-
-#Test Screenshots
+#Test Tools and Artifacts
 web_*.jpg
+bin/phantomjs
 
 #API Container - Cache Directory
 cache


### PR DESCRIPTION
The _PhantomJS_ Executable will be downloaded live only in the Testing Environment.

Due to the _Glitch_ Deployment Requirement documented at
[_PhantomJS_ Executable consumes all Disc Space](https://github.com/bodo-hugo-barwich/plack-pwa-web/issues/11)
The Executable must be removed from the Project and only downloaded live during the Testing Sequence.